### PR TITLE
fix(server): Explicitly require 'pg' for Vercel deployment

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -1,4 +1,5 @@
 const { Sequelize } = require('sequelize');
+require('pg');
 require('dotenv').config({ path: __dirname + '/.env' });
 
 if (!process.env.DATABASE_URL) {


### PR DESCRIPTION
- Adds `require('pg')` to the top of `server/db.js`.
- This fixes a common issue where serverless environments like Vercel fail to bundle the `pg` package, which is a peer dependency of Sequelize, causing a runtime error.
- Explicitly requiring the package ensures it is included in the build output, resolving the 'Please install pg package manually' error.