### PR TITLE
fix(server): handle missing authorization header

### DIFF
--- a/server/middleware/authMiddleware.js
+++ b/server/middleware/authMiddleware.js
@@ -5,6 +5,9 @@ module.exports = function (req, res, next){
         next()
     }
     try {
+        if (!req.headers.authorization) {
+            return res.status(401).json({message:"Не авторизован"});
+        }
         const token = req.headers.authorization.split(' ')[1]
         if (!token || token === 'null') {
             return res.status(401).json({message:"Не авторизован"})


### PR DESCRIPTION
Previously, the auth middleware would crash if the Authorization header was missing from a request. This would cause a TypeError when trying to call .split() on `undefined`.

This commit adds a check to ensure the Authorization header exists before attempting to process it, preventing the server from crashing and ensuring a proper 401 response is sent.