### PR TITLE
Fix: Исправлена загрузка изображений

### DIFF
--- a/client/src/components/DeviceItem.js
+++ b/client/src/components/DeviceItem.js
@@ -19,8 +19,8 @@ const DeviceItem = observer(({device}) => {
     const [ratingVisible, setRatingVisible] = useState(false)
     const [imaging, setImaging] = useState(false)
 
-    const sold2 = process.env.REACT_APP_API_URL + device.imgg;
-    const sold = process.env.REACT_APP_API_URL + device.img;
+    const sold2 = process.env.REACT_APP_API_URL + '/static/' + device.imgg;
+    const sold = process.env.REACT_APP_API_URL + '/static/' + device.img;
 
     const formattedPrice = `${device.price.toFixed(0)}`;
     const oldPrice = formattedPrice*1.5;

--- a/server/index.js
+++ b/server/index.js
@@ -19,7 +19,7 @@ app.use(cors({
     credentials: true
 }));
 app.use(express.json())
-app.use(express.static(path.resolve(__dirname, 'static')))
+app.use('/static', express.static(path.resolve(__dirname, 'static')))
 app.use(fileUpload({}))
 app.use('/api', router)
 


### PR DESCRIPTION
Проблема заключалась в том, что сервер не был настроен для корректной раздачи статических файлов, а клиент формировал неправильные URL для изображений.

- В `server/index.js` добавлена раздача статических файлов из директории `static` по префиксу `/static`.
- В `client/src/components/DeviceItem.js` обновлено формирование URL изображений с учетом нового префикса.