### PR TITLE
Fix: Исправлена загрузка оставшихся изображений

### DIFF
--- a/client/src/components/BackType.js
+++ b/client/src/components/BackType.js
@@ -17,7 +17,7 @@ const BackType = observer(() => {
                     className="p-3"
                     border={brand.id === device.selectedBrand.id ? 'danger' : 'light'}
                 >
-                    <Image width={20} height={20} src={process.env.REACT_APP_API_URL + brand.img}/>{brand.name}
+                    <Image width={20} height={20} src={process.env.REACT_APP_API_URL + '/static/' + brand.img}/>{brand.name}
                 </Card>
             )}
         </Form>

--- a/client/src/components/BrandBar.js
+++ b/client/src/components/BrandBar.js
@@ -25,7 +25,7 @@ const BrandBar = observer(() => {
                     onClick={() => device.setSelectedBrand(brand)}
                     border={brand.id === device.selectedBrand.id ? 'dark' : 'light'}
                 >
-                    <div className={styles.ico}><div><Image width={40}src={process.env.REACT_APP_API_URL + brand.img}></Image></div></div><br></br>
+                    <div className={styles.ico}><div><Image width={40}src={process.env.REACT_APP_API_URL + '/static/' + brand.img}></Image></div></div><br></br>
                 </div>
             )}
             </div>

--- a/client/src/components/Brandy.js
+++ b/client/src/components/Brandy.js
@@ -9,7 +9,7 @@ const Brandy = observer(() => {
 
     return (
         <div>
-            <Image width={20} height={20} src={process.env.REACT_APP_API_URL + brand.img}/>
+            <Image width={20} height={20} src={process.env.REACT_APP_API_URL + '/static/' + brand.img}/>
         </div>
     );
 });

--- a/client/src/components/Cart/CartItem.js
+++ b/client/src/components/Cart/CartItem.js
@@ -9,7 +9,7 @@ const CartItem = (props) => {
   return (
     <li className={classes["cart-item"]}>
       <div style={{display:'flex', alignItems:'center', justifyContent:'flex-start'}}>
-      <Image style={{cursor:'pointer', flexBasis:'80px'}} onClick={() => navigate(DEVICE_ROUTE + '/' + props.id)} width={50} src={process.env.REACT_APP_API_URL + props.image}/>
+      <Image style={{cursor:'pointer', flexBasis:'80px'}} onClick={() => navigate(DEVICE_ROUTE + '/' + props.id)} width={50} src={process.env.REACT_APP_API_URL + '/static/' + props.image}/>
         <span style={{fontSize:'10px', flexBasis:'100px'}}>{props.name}</span>
         <div  style={{flexBasis:'80px'}} className={classes.summary}>
           <span className={classes.price}>{price}</span>

--- a/client/src/components/ComputedType.js
+++ b/client/src/components/ComputedType.js
@@ -17,7 +17,7 @@ const ComputedType = observer(() => {
                     key={type.id}
                 >
                     {type.name}
-                    <Image src={process.env.REACT_APP_API_URL + type.img}/>
+                    <Image src={process.env.REACT_APP_API_URL + '/static/' + type.img}/>
                 </ListGroup.Item>
             )}
         </ListGroup>

--- a/client/src/components/Meals/MealItem/MealItem.js
+++ b/client/src/components/Meals/MealItem/MealItem.js
@@ -28,7 +28,7 @@ const MealItem = (props) => {
         <div>
             <h3 onClick={() => navigate(DEVICE_ROUTE + '/' + props.pid)}>{props.name}</h3>
             <div className={styles.name}>{props.name}</div>
-            <div><Image width={100} height={100} src={process.env.REACT_APP_API_URL + props.ima}/></div>
+            <div><Image width={100} height={100} src={process.env.REACT_APP_API_URL + '/static/' + props.ima}/></div>
             <div className={styles.price}>{formattedPrice}</div>
             
         </div>

--- a/client/src/components/NewComponent.js
+++ b/client/src/components/NewComponent.js
@@ -19,7 +19,7 @@ const NewComponent = observer((props) => {
     return (
                 <div>
                                 <div>
-                                    <Image height={20}  src={process.env.REACT_APP_API_URL + result.img}/>
+                                    <Image height={20}  src={process.env.REACT_APP_API_URL + '/static/' + result.img}/>
                                 </div>
                 </div>
     );

--- a/client/src/components/modals/CreateDevice.js
+++ b/client/src/components/modals/CreateDevice.js
@@ -107,7 +107,7 @@ const CreateDevice = observer(({show, onHide}) => {
                                     key={brand.id}
                                 >
                                     {brand.name}
-                                    <Image width={20} height={20} src={process.env.REACT_APP_API_URL + brand.img}/>
+                                    <Image width={20} height={20} src={process.env.REACT_APP_API_URL + '/static/' + brand.img}/>
                                 </Dropdown.Item>
                             )}
                         </Dropdown.Menu>

--- a/client/src/pages/DevicePage.js
+++ b/client/src/pages/DevicePage.js
@@ -39,8 +39,8 @@ const DevicePage = () => {
         <Container className="mt-3">
             <div style={{display:'flex', maxHeight:'500px'}}>
 
-                    <Image width={400} src={process.env.REACT_APP_API_URL + device.img}/>
-                    <Image width={400} src={process.env.REACT_APP_API_URL + device.imgg}/>
+                    <Image width={400} src={process.env.REACT_APP_API_URL + '/static/' + device.img}/>
+                    <Image width={400} src={process.env.REACT_APP_API_URL + '/static/' + device.imgg}/>
                     <Card
                         className="d-flex flex-column align-items-center justify-content-around"
                         style={{backgroundColor:'#000', border: '0px solid lightgray'}}


### PR DESCRIPTION
Это исправление является дополнением к предыдущему. Некоторые компоненты все еще формировали неверные URL-адреса для изображений, что приводило к ошибкам загрузки.

- Обновлены все оставшиеся компоненты (`DevicePage`, `CartItem`, `BrandBar` и др.), чтобы они использовали правильный префикс `/static/` при формировании URL-адресов изображений.