### PR TITLE
fix: Implement correct custom cursor logic based on feedback

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -18,6 +18,7 @@ import TypeBar from './components/TypeBar';
 import UserBar from './components/UserBar';
 import Other from './pages/Other';
 import useCustomCursor from './hooks/useCustomCursor';
+import './cursor.css';
 
 const App = observer(() => {
     useCustomCursor();

--- a/client/src/cursor.css
+++ b/client/src/cursor.css
@@ -1,0 +1,17 @@
+/* Set a default cursor for the whole page */
+body {
+  cursor: url('https://i.postimg.cc/W3VXrbXS/pp.png'), auto;
+}
+
+/*
+  Override the default browser pointer for interactive elements.
+  !important is necessary to ensure this rule takes precedence.
+*/
+a,
+button,
+[role="button"],
+input[type="submit"],
+input[type="button"],
+input[type="reset"] {
+  cursor: url('https://i.postimg.cc/CKn93Bbm/123343.png'), auto !important;
+}

--- a/client/src/hooks/useCustomCursor.js
+++ b/client/src/hooks/useCustomCursor.js
@@ -1,85 +1,65 @@
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 
 // URLs provided by the user
 const CURSOR_DEFAULT = 'https://i.postimg.cc/W3VXrbXS/pp.png';
 const CURSOR_LEFT_CLICK = 'https://i.postimg.cc/CKC6c6rF/1.png';
 const CURSOR_RIGHT_CLICK = 'https://i.postimg.cc/PJzrkdCY/p1.png';
-const CURSOR_POINTER = 'https://i.postimg.cc/CKn93Bbm/123343.png'; // New cursor for links/buttons
+const CURSOR_POINTER = 'https://i.postimg.cc/CKn93Bbm/123343.png';
 
 // Named function for the context menu handler to ensure it can be removed correctly
 const preventContextMenu = (e) => e.preventDefault();
 
 const useCustomCursor = () => {
-  // Use a ref to store the current cursor state ('default', 'left', 'right')
-  const cursorState = useRef('default');
-
-  const setCursor = (cursorUrl) => {
-    document.body.style.cursor = `url(${cursorUrl}), auto`;
-  };
-
   useEffect(() => {
+    const setCursor = (cursorUrl) => {
+      // We check if the target is interactive and apply the pointer cursor if so.
+      // This is a fallback for the CSS, but the CSS !important rule should take precedence.
+      const target = event.target;
+      if (target && (target.tagName === 'A' || target.tagName === 'BUTTON' || target.closest('a') || target.closest('button'))) {
+          document.body.style.cursor = `url(${CURSOR_POINTER}), auto`;
+          return;
+      }
+      document.body.style.cursor = `url(${cursorUrl}), auto`;
+    };
+
     const handleMouseDown = (e) => {
       const target = e.target;
-
-      // If clicking on a link or button, let handleMouseMove manage the cursor.
-      // Just prevent the click state from being activated.
+      // Do not change cursor if clicking on an interactive element, let CSS handle it.
       if (target.tagName === 'A' || target.tagName === 'BUTTON' || target.closest('a') || target.closest('button')) {
-        cursorState.current = 'default'; // Reset state on click of interactive element
-        return;
+          return;
       }
 
-      if (e.button === 0) { // Left click
-        if (cursorState.current === 'left') {
-          cursorState.current = 'default';
-          setCursor(CURSOR_DEFAULT);
-        } else {
-          cursorState.current = 'left';
+      switch (e.button) {
+        case 0: // Left click
           setCursor(CURSOR_LEFT_CLICK);
-        }
-      } else if (e.button === 2) { // Right click
-        if (cursorState.current === 'right') {
-          cursorState.current = 'default';
-          setCursor(CURSOR_DEFAULT);
-        } else {
-          cursorState.current = 'right';
+          break;
+        case 2: // Right click
           setCursor(CURSOR_RIGHT_CLICK);
-        }
+          break;
+        default:
+          break;
       }
     };
 
-    const handleMouseMove = (e) => {
+    const handleMouseUp = (e) => {
         const target = e.target;
+        // Revert to the default cursor on mouse up
         if (target.tagName === 'A' || target.tagName === 'BUTTON' || target.closest('a') || target.closest('button')) {
-            // Use the new pointer cursor when hovering over links/buttons
             setCursor(CURSOR_POINTER);
         } else {
-            // When moving off an interactive element, restore the correct cursor based on the stored state
-            switch (cursorState.current) {
-                case 'left':
-                    setCursor(CURSOR_LEFT_CLICK);
-                    break;
-                case 'right':
-                    setCursor(CURSOR_RIGHT_CLICK);
-                    break;
-                default:
-                    setCursor(CURSOR_DEFAULT);
-                    break;
-            }
+            setCursor(CURSOR_DEFAULT);
         }
     };
-
-    // Set initial cursor
-    setCursor(CURSOR_DEFAULT);
 
     // Add all event listeners
     document.addEventListener('mousedown', handleMouseDown);
-    document.addEventListener('mousemove', handleMouseMove);
+    document.addEventListener('mouseup', handleMouseUp);
     document.addEventListener('contextmenu', preventContextMenu);
 
     // Cleanup function to remove listeners and reset cursor
     return () => {
       document.removeEventListener('mousedown', handleMouseDown);
-      document.removeEventListener('mousemove', handleMouseMove);
+      document.removeEventListener('mouseup', handleMouseUp);
       document.removeEventListener('contextmenu', preventContextMenu);
       document.body.style.cursor = 'auto'; // Reset to default browser cursor
     };


### PR DESCRIPTION
This commit completely refactors the custom cursor implementation to align with the user's final request.

The previous stateful "toggle" logic has been removed. The new implementation provides a more intuitive "press-and-hold" effect:
- The cursor changes to the appropriate image on `mousedown` (left or right click).
- It immediately reverts to the default custom cursor on `mouseup`.

A new CSS file (`client/src/cursor.css`) has been introduced to solve the issue where browser default styles overrode the custom cursor on interactive elements. This file now uses an `!important` rule to ensure the user-provided "pointer" image is consistently displayed when hovering over links and buttons.

The `useCustomCursor` hook has been simplified to work in tandem with the new CSS file, and it is now imported correctly in `App.js`. This version is stable, efficient, and directly addresses all points from the latest user feedback.