### PR TITLE
fix: Resolve ESLint error and simplify cursor logic

### DIFF
--- a/client/src/hooks/useCustomCursor.js
+++ b/client/src/hooks/useCustomCursor.js
@@ -4,51 +4,35 @@ import { useEffect } from 'react';
 const CURSOR_DEFAULT = 'https://i.postimg.cc/W3VXrbXS/pp.png';
 const CURSOR_LEFT_CLICK = 'https://i.postimg.cc/CKC6c6rF/1.png';
 const CURSOR_RIGHT_CLICK = 'https://i.postimg.cc/PJzrkdCY/p1.png';
-const CURSOR_POINTER = 'https://i.postimg.cc/CKn93Bbm/123343.png';
 
 // Named function for the context menu handler to ensure it can be removed correctly
 const preventContextMenu = (e) => e.preventDefault();
 
 const useCustomCursor = () => {
   useEffect(() => {
-    const setCursor = (cursorUrl) => {
-      // We check if the target is interactive and apply the pointer cursor if so.
-      // This is a fallback for the CSS, but the CSS !important rule should take precedence.
-      const target = event.target;
-      if (target && (target.tagName === 'A' || target.tagName === 'BUTTON' || target.closest('a') || target.closest('button'))) {
-          document.body.style.cursor = `url(${CURSOR_POINTER}), auto`;
-          return;
-      }
-      document.body.style.cursor = `url(${cursorUrl}), auto`;
-    };
-
     const handleMouseDown = (e) => {
       const target = e.target;
-      // Do not change cursor if clicking on an interactive element, let CSS handle it.
+      // Do not change cursor if clicking on an interactive element; let CSS handle it.
       if (target.tagName === 'A' || target.tagName === 'BUTTON' || target.closest('a') || target.closest('button')) {
-          return;
+        return;
       }
 
       switch (e.button) {
         case 0: // Left click
-          setCursor(CURSOR_LEFT_CLICK);
+          document.body.style.cursor = `url(${CURSOR_LEFT_CLICK}), auto`;
           break;
         case 2: // Right click
-          setCursor(CURSOR_RIGHT_CLICK);
+          document.body.style.cursor = `url(${CURSOR_RIGHT_CLICK}), auto`;
           break;
         default:
           break;
       }
     };
 
-    const handleMouseUp = (e) => {
-        const target = e.target;
-        // Revert to the default cursor on mouse up
-        if (target.tagName === 'A' || target.tagName === 'BUTTON' || target.closest('a') || target.closest('button')) {
-            setCursor(CURSOR_POINTER);
-        } else {
-            setCursor(CURSOR_DEFAULT);
-        }
+    const handleMouseUp = () => {
+        // On mouse up, always revert to the default cursor.
+        // The CSS rule will handle displaying the pointer cursor over interactive elements.
+        document.body.style.cursor = `url(${CURSOR_DEFAULT}), auto`;
     };
 
     // Add all event listeners


### PR DESCRIPTION
This commit fixes a build failure caused by an `eslint` `no-restricted-globals` error. The incorrect usage of a global `event` object in the `useCustomCursor` hook has been removed.

The hook's logic has been further simplified:
- It now only handles `mousedown` and `mouseup` events to change the cursor during a click.
- It no longer contains any `mousemove` logic, as the cursor for interactive elements is now exclusively and more reliably handled by the `cursor.css` file with an `!important` rule.

This change resolves the build error and makes the implementation more robust and easier to maintain.