### PR TITLE
feat: Make footer sticky and overlap content

### DIFF
--- a/client/src/components/Layout/Footer.js
+++ b/client/src/components/Layout/Footer.js
@@ -7,7 +7,7 @@ import styles from './Header.module.css';
 const Footer = () => {
 
     return <React.Fragment>
-<footer style={{width:'100%', position:'sticky', top:'0', height:'100vh', left:'0', zIndex:'7', backgroundColor:'#0b0b0b'}} className="text-center text-lg-start text-muted">
+<footer style={{width:'100%', position:'sticky', bottom:'0', left:'0', zIndex:'100', backgroundColor:'#0b0b0b'}} className="text-center text-lg-start text-muted">
 
   <section className="d-flex justify-content-center justify-content-lg-between p-0">
 


### PR DESCRIPTION
This change modifies the footer to be sticky at the bottom of the page.

- Updates the inline styles in `Footer.js` to use `position: 'sticky'`, `bottom: '0'`, and a `zIndex` of `100`.
- This ensures the footer remains at the bottom of the viewport and overlaps the red "Hello" block on scroll, as requested.