### PR TITLE
feat: Refactor homepage routing and fix footer overlap

### DIFF
--- a/client/src/components/Layout/Footer.js
+++ b/client/src/components/Layout/Footer.js
@@ -7,7 +7,7 @@ import styles from './Header.module.css';
 const Footer = () => {
 
     return <React.Fragment>
-<footer style={{width:'100%', position:'sticky', top:'0', height:'100vh', left:'0', zIndex:'7', backgroundColor:'#0b0b0b'}} className="text-center text-lg-start text-muted">
+<footer style={{width:'100%', position: 'relative', zIndex: 100, backgroundColor:'#0b0b0b'}} className="text-center text-lg-start text-muted">
 
   <section className="d-flex justify-content-center justify-content-lg-between p-0">
 

--- a/client/src/components/Menu.js
+++ b/client/src/components/Menu.js
@@ -3,7 +3,7 @@ import Logo from './Logo';
 import styles from './Menu.module.css';
 import NavBar from './NavBar';
 import {useNavigate} from 'react-router-dom'
-import {OTHER_ROUTE} from "../utils/consts";
+import {OTHER_ROUTE, MAGAZINE_ROUTE} from "../utils/consts";
 
 
 function Menu() {
@@ -21,7 +21,9 @@ function Menu() {
                                       >
                                           Админка
                                       </button></span>
-      <span className={styles.tip}>MAGAZINE</span>
+      <span className={styles.tip} onClick={() => history(MAGAZINE_ROUTE)} style={{cursor: 'pointer'}}>
+                                          MAGAZINE
+                                      </span>
       <span className={styles.tip}>CONTACTS</span>
       <div>
       <NavBar />

--- a/client/src/pages/HomePage.js
+++ b/client/src/pages/HomePage.js
@@ -1,0 +1,13 @@
+import React from 'react';
+
+const HomePage = () => {
+    return (
+        <div>
+            {/* This is the new main page. It's intentionally left empty
+                as per the user's request. The main layout components
+                are rendered in App.js. */}
+        </div>
+    );
+};
+
+export default HomePage;

--- a/client/src/routes.js
+++ b/client/src/routes.js
@@ -1,7 +1,8 @@
-import {ADMIN_ROUTE, BASKET_ROUTE, DEVICE_ROUTE, LOGIN_ROUTE, REGISTRATION_ROUTE, SHOP_ROUTE, TVOROG_ROUTE, OTHER_ROUTE, ADDJOKE_ROUTE, JOKEDETAILS_ROUTE, JOKES_ROUTE} from "./utils/consts";
+import {ADMIN_ROUTE, BASKET_ROUTE, DEVICE_ROUTE, LOGIN_ROUTE, REGISTRATION_ROUTE, SHOP_ROUTE, MAGAZINE_ROUTE, TVOROG_ROUTE, OTHER_ROUTE, ADDJOKE_ROUTE, JOKEDETAILS_ROUTE, JOKES_ROUTE} from "./utils/consts";
 import Admin from "./pages/Admin";
 import Basket from "./pages/Basket";
 import Shop from "./pages/Shop";
+import HomePage from "./pages/HomePage";
 import Other from "./pages/Other";
 import Auth from "./pages/Auth";
 import DevicePage from "./pages/DevicePage";
@@ -25,6 +26,10 @@ export const authRoutes = [
 export const publicRoutes = [
     {
         path: SHOP_ROUTE,
+        Component: HomePage
+    },
+    {
+        path: MAGAZINE_ROUTE,
         Component: Shop
     },
     {

--- a/client/src/utils/consts.js
+++ b/client/src/utils/consts.js
@@ -2,6 +2,7 @@ export const ADMIN_ROUTE = '/admin'
 export const LOGIN_ROUTE = '/login'
 export const REGISTRATION_ROUTE = '/registration'
 export const SHOP_ROUTE = "/"
+export const MAGAZINE_ROUTE = '/magazine'
 export const RATING_ROUTE = "/rating"
 export const BASKET_ROUTE = '/basket'
 export const DEVICE_ROUTE = '/device'


### PR DESCRIPTION
This commit introduces two main changes:

1.  **Refactors the application's routing:**
    -   The main page content (the `Shop` component) has been moved from the root path (`/`) to a new `/magazine` route.
    -   A new, empty `HomePage` component is now rendered at the root path.
    -   A "MAGAZINE" link has been added to the `Menu.js` component to navigate to the new `/magazine` page.

2.  **Fixes the footer's visual behavior:**
    -   The `Footer.js` component's CSS has been changed from `position: sticky` to `position: relative` with a `zIndex` of `100`.
    -   This allows the footer to correctly scroll over the sticky red block (`Other.js`) as intended by the user.